### PR TITLE
Fix acking.

### DIFF
--- a/cmd/consume.go
+++ b/cmd/consume.go
@@ -104,7 +104,7 @@ Use comma-separated values for binding the same queue with multiple routing keys
 		msgs, err := ch.Consume(
 			queue,     // queue
 			"",        // consumer id
-			!noAck,    // auto-ack
+			false,    // auto-ack
 			exclusive, // exclusive
 			false,     // no-local
 			false,     // no-wait
@@ -131,6 +131,10 @@ Use comma-separated values for binding the same queue with multiple routing keys
 					if val, err := reflections.GetField(msg, key); err == nil && val != reflect.Zero(reflect.TypeOf(val)).Interface() {
 						fmt.Printf("%s: %q\n", key, val)
 					}
+				}
+
+				if !noAck {
+					ch.Ack(msg.DeliveryTag, false)
 				}
 
 				count++


### PR DESCRIPTION
no-ack should not mean be about auto-ack but rahter if we ack a message
at all.
This way we can actually get 1 message. Otherwise with auto-acking, we
get more messages even with prefetch = 1; as the server will just push
them to us. With --no-ack specified, we would not even pop 1 message
from the server, it will always reque